### PR TITLE
Fix invalid elif statements

### DIFF
--- a/src/addon.cc
+++ b/src/addon.cc
@@ -19,7 +19,7 @@ NODE_API_MODULE(rpi_led_matrix, Init)
 	#pragma GCC diagnostic ignored "-Wunused-variable"
 	#ifdef __GNUC__
 		#warning "Local machine is not a Raspberry Pi; skipping compilation of full addon module."
-	#elif
+	#else
 		#pragma message("Local machine is not a Raspberry Pi; skipping compilation of full addon module.")
 	#endif
 

--- a/src/unsupported.cc
+++ b/src/unsupported.cc
@@ -10,7 +10,7 @@
 #	pragma GCC diagnostic ignored "-Wunused-variable"
 #	ifdef __GNUC__
 #		warning "Skipping link of rpi-rgb-led-matrix library."
-#	elif
+#	else
 #		pragma message("Skipping link of rpi-rgb-led-matrix library.")
 #	endif
 #endif


### PR DESCRIPTION
Elif without a condition was causing the build to fail on windows environments. 
I don't have the ability to extensively test this in a linux environment, however considering that this changes invalid yet supported syntax to valid syntax, I don't imagine that it could cause any giant failures.