### PR TITLE
Fixed examples, updated vendor library to take advantage of new row address types and mappings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ enum MuxType {
 enum RowAddressType {
   Direct = 0,
   AB = 1,
+  DirectRow = 2,
+  ABC = 3,
+  ABCShift = 4
 }
 ```
 

--- a/examples/kitchen-sink.ts
+++ b/examples/kitchen-sink.ts
@@ -126,7 +126,7 @@ const spin = async (matrix: LedMatrixInstance, speed = 50, clear = true) => {
     matrix.clear();
     for (let y = 0; y < matrix.height(); y++) {
       matrix
-        .fgColor(rainbow64[y])
+        .fgColor(rainbow64[y % 64])
         .drawLine(0, y, matrix.width(), y)
         .sync();
       await wait(22);

--- a/examples/sync-hooks.ts
+++ b/examples/sync-hooks.ts
@@ -29,9 +29,10 @@ class Pulser {
     }
 
     matrix.afterSync((mat, dt, t) => {
-      return pulsers.map(pulser => {
+      pulsers.map(pulser => {
         matrix.fgColor(pulser.nextColor(t)).setPixel(pulser.x, pulser.y);
       });
+      setTimeout(() => matrix.sync(), 0);
     });
 
     matrix.sync();

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "lint": "tslint -c ./tslint.json --project examples && tslint -c ./tslint.json --project src",
     "merge-submodule-upstream": "(cd vendor && git fetch && git merge origin/master)",
     "prepublishOnly": "npm run lint && npm run build",
+    "prepare": "npm run lint && npm run build",
     "quick-build": "rimraf dist && node-gyp build && tsc -p src",
     "sync-changes": "echo 'Changes will be pushed to Raspberry Pi' && nodemon --config nodemon.sync.json"
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,12 +21,16 @@ export enum PixelMapperType {
   Chainlink = 'Chainlink',
   U = 'U-mapper',
   Rotate = 'Rotate',
+  V = 'V-mapper',
+  VZ = 'V-mapper:Z',
 }
 
 export type PixelMapper
   = { type: PixelMapperType.Rotate; angle: number }
   | { type: PixelMapperType.Chainlink }
-  | { type: PixelMapperType.U };
+  | { type: PixelMapperType.U }
+  | { type: PixelMapperType.V }
+  | { type: PixelMapperType.VZ };
 
 /**
  * If a runtime option is set to Disabled, it's command line flag will be unavailable.
@@ -51,9 +55,13 @@ export enum RowAddressType {
    */
   DirectRow = 2,
   /**
-   * ABC shift + DE direct
+   * ABC addressed panels
    */
   ABC = 3,
+  /**
+   * 4 = ABC Shift + DE direct
+   */
+  ABCShift = 4,
 }
 
 export enum GpioMapping {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,8 @@ export class LedMatrixUtils {
           case PixelMapperType.Chainlink: return PixelMapperType.Chainlink;
           case PixelMapperType.Rotate: return [PixelMapperType.Rotate, mapper.angle].join(':');
           case PixelMapperType.U: return PixelMapperType.U;
+          case PixelMapperType.V: return PixelMapperType.V;
+          case PixelMapperType.VZ: return PixelMapperType.VZ;
         }
       })
       .join(';');


### PR DESCRIPTION
There were two problems I had with the examples:

1.  The kitchen sink would break because it assumes the height was 64 pixels or less
2. The sync example would cause a memory leak, fixed as per the instruction in the README

I also updated the vendor library to take advantage of the new row address type and pixel mappings.