### PR TITLE
Add support to offset drawBuffers.

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,6 @@
   "bracketSpacing": true,
   "singleQuote": true,
   "trailingComma": "es5",
-  "printWidth": 80
+  "printWidth": 80,
+  'endOfLine': 'auto',
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rpi-led-matrix",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rpi-led-matrix",
-      "version": "1.14.0",
+      "version": "1.15.0",
       "license": "MITNFA",
       "dependencies": {
         "bindings": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rpi-led-matrix",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "Node.js/Typescript bindings for hzeller/rpi-rgb-led-matrix",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/led-matrix.addon.cc
+++ b/src/led-matrix.addon.cc
@@ -187,6 +187,8 @@ Napi::Value LedMatrixAddon::draw_buffer(const Napi::CallbackInfo& info) {
 	const auto buffer = info[0].As<Napi::Buffer<uint8_t> >();
 	const auto w	  = info[1].IsNumber() ? info[1].As<Napi::Number>().Uint32Value() : this->matrix_->width();
 	const auto h	  = info[2].IsNumber() ? info[2].As<Napi::Number>().Uint32Value() : this->matrix_->height();
+	const auto xO	  = info[3].IsNumber() ? info[3].As<Napi::Number>().Int32Value() : 0; //Offset for x Coordinate
+	const auto yO	  = info[4].IsNumber() ? info[4].As<Napi::Number>().Int32Value() : 0; //Offset for y Coordinate
 	const auto data	  = buffer.Data();
 	const auto len	  = buffer.Length();
 
@@ -211,8 +213,10 @@ Napi::Value LedMatrixAddon::draw_buffer(const Napi::CallbackInfo& info) {
 		if (y > h) break;
 		for (unsigned int x = 0; x < w; x++) {
 			if (x > w) break;
+			if (x + xO > this->matrix_->width() || x + xO < 0 || y + yO > this->matrix_->height() || y + yO < 0) continue; //Skip anything that wont be drawn
+
 			auto pixel = img->getPixel(x, y);
-			this->canvas_->SetPixel(x, y, pixel.r(), pixel.g(), pixel.b());
+			this->canvas_->SetPixel(x + xO, y + yO, pixel.r(), pixel.g(), pixel.b());
 		}
 	}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -317,7 +317,13 @@ export interface LedMatrixInstance {
   clear(): this;
   clear(x0: number, y0: number, x1: number, y1: number): this;
 
-  drawBuffer(buffer: Buffer | Uint8Array, w?: number, h?: number, xO?: number, yO?: number): this;
+  drawBuffer(
+    buffer: Buffer | Uint8Array,
+    w?: number,
+    h?: number,
+    xO?: number,
+    yO?: number
+  ): this;
   drawCircle(x: number, y: number, r: number): this;
   drawLine(x0: number, y0: number, x1: number, y1: number): this;
   drawRect(x0: number, y0: number, width: number, height: number): this;

--- a/src/types.ts
+++ b/src/types.ts
@@ -317,7 +317,7 @@ export interface LedMatrixInstance {
   clear(): this;
   clear(x0: number, y0: number, x1: number, y1: number): this;
 
-  drawBuffer(buffer: Buffer | Uint8Array, w?: number, h?: number): this;
+  drawBuffer(buffer: Buffer | Uint8Array, w?: number, h?: number, xO?: number, yO?: number): this;
   drawCircle(x: number, y: number, r: number): this;
   drawLine(x0: number, y0: number, x1: number, y1: number): this;
   drawRect(x0: number, y0: number, width: number, height: number): this;


### PR DESCRIPTION
This simply adds a x and y offset to drawBuffer. This allows users to be able to scroll images/buffers. Currently if you want to scroll an image across the matrix you would need to create a buffer the size of the matrix(s) and fill any blanks with black, then a new buffer for each _frame_ of the scroll (offsetting the image x pixels and then syncing).

Quick example for image scrolling:

```
function drawImage(buffer, w, h)
{
        canvas.clear();

	if(drawImage.xOffset > canvas.width())
		drawImage.xOffset = 0;

	canvas.drawBuffer(buffer, w, h, drawImage.xOffset, 0);

	drawImage.xOffset++;

	canvas.sync();
}
```